### PR TITLE
Fix profile d creation order

### DIFF
--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -22,9 +22,10 @@ define authclientconfig::profile (
   $action = bool2str($enabled, 'enable', 'disable')
 
   file { "profile_${profile}":
-    path   => "${profile_dir}/${profile}-acc-profile",
-    source => $source,
-    notify => Exec["${action}_profile"],
+    path    => "${profile_dir}/${profile}-acc-profile",
+    source  => $source,
+    notify  => Exec["${action}_profile"],
+    require => Class[authclientconfig],
   }
 
   if $enabled {


### PR DESCRIPTION
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/auth-client-config/profile.d/avature-acc-profile20200812-5990-wbfp2b.lock (file: /etc/puppetlabs/code/environments/qa/modules/authclientconfig/manifests/profile.pp, line: 24)
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/auth-client-config/profile.d/avature-acc-profile20200812-5990-wbfp2b.lock (file: /etc/puppetlabs/code/environments/qa/modules/authclientconfig/manifests/profile.pp, line: 24)
...
Notice: /Stage[main]/Authclientconfig/Package[auth-client-config]/ensure: created
...